### PR TITLE
recreate dummy files for windows

### DIFF
--- a/hidapi/dummy.go
+++ b/hidapi/dummy.go
@@ -1,0 +1,4 @@
+//go:build windows
+// +build windows
+
+package hidapi

--- a/hidapi/hidapi/windows.go
+++ b/hidapi/hidapi/windows.go
@@ -1,0 +1,4 @@
+//go:build windows
+// +build windows
+
+package hidapi

--- a/hidapi/libusb/dummy.go
+++ b/hidapi/libusb/dummy.go
@@ -1,0 +1,4 @@
+//go:build windows
+// +build windows
+
+package libusb

--- a/hidapi/mac/dummy.go
+++ b/hidapi/mac/dummy.go
@@ -1,0 +1,4 @@
+//go:build windows
+// +build windows
+
+package mac

--- a/hidapi/windows/dummy.go
+++ b/hidapi/windows/dummy.go
@@ -1,0 +1,4 @@
+//go:build windows
+// +build windows
+
+package windows


### PR DESCRIPTION
This is the second part of the fix to get holiman/usb#43 to build. These packages were unavailable for the windows build, which caused some compilation error.

This means usb will not work on windows, as this is not implemented, but that's fine as I don't think there is a use case for that. If that use case arises, we can always try to activate it then.